### PR TITLE
Add a destroy method

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -11,6 +11,7 @@ var Manager = function (options) {
     self.nipples.on = self.on.bind(self);
     self.nipples.off = self.off.bind(self);
     self.nipples.options = self.options;
+    self.nipples.destroy = self.destroy.bind(self);
     self.nipples.get = function (id) {
         for (var i = 0, max = self.nipples.length; i < max; i += 1) {
             if (self.nipples[i].identifier === id) {
@@ -270,3 +271,9 @@ Manager.prototype.processOnEnd = function (evt) {
     var index = self.nipples.indexOf(nipple);
     self.nipples.splice(index, 1);
 };
+
+// Cleanly destroy the manager
+Manager.prototype.destroy = function() {
+    this.off();
+    this.unbindEvt(this.options.zone, 'start');
+}


### PR DESCRIPTION
Created manager never unbind for events and do not expose unbind. This PR aims to fix this.

A public destroy method is a good way to let user create then clearing a view (I think about view as a Backbone.Marionette user, but it's the same for React, Ember, ...), then go back, re-create, etc, safely, without memory leak or issues due to events.
